### PR TITLE
format as operator

### DIFF
--- a/src/main/scala/stdlib/Formatting.scala
+++ b/src/main/scala/stdlib/Formatting.scala
@@ -46,11 +46,11 @@ object Formatting extends FlatSpec with Matchers with org.scalaexercises.definit
     "%c".format(f) should be(res3)
   }
 
-  /** Formatting can also include numbers:
+  /** "format" is also an operator, and formatting can also include numbers:
    */
   def includingNumbersFormatting(res0: String) {
     val j = 190
-    "%d bottles of beer on the wall" format j - 100 should be(res0)
+    "%d bottles of beer on the wall" format j - 100 should be(res0) // no dot before format
   }
 
   /** Formatting can be used for any number of items, like a string and a number:


### PR DESCRIPTION
The line `"%d bottles of beer on the wall" format j - 100 should be(res0)` shows that `format` is both a member function of the type String and also an operator on the type String.  I wanted to call attention to that for those like me who are learning Scala through these exercises.